### PR TITLE
parameter to manipulate connect-options of the test-schema

### DIFF
--- a/lib/DBICx/TestDatabase.pm
+++ b/lib/DBICx/TestDatabase.pm
@@ -10,7 +10,7 @@ our $VERSION = '0.05';
 my @TMPFILES;
 
 sub new {
-    my ($class, $schema_class, $opts) = @_;
+    my ($class, $schema_class, $opts, $schema_opts) = @_;
 
     eval "require $schema_class"
       or die "failed to require $schema_class: $@";
@@ -22,8 +22,10 @@ sub new {
         push @TMPFILES, $filename;
     }
 
-    my $schema = $schema_class->connect( "DBI:SQLite:$filename", '', '',
-        { sqlite_unicode => 1 } )
+    $schema_opts ||= {};
+    $schema_opts->{sqlite_unicode} = 1;
+
+    my $schema = $schema_class->connect( "DBI:SQLite:$filename", '', '', $schema_opts )
         or die "failed to connect to DBI:SQLite:$filename ($schema_class)";
 
     $schema->deploy unless $opts->{nodeploy};

--- a/t/schema_opts.t
+++ b/t/schema_opts.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 1;
+
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+
+use DBICx::TestDatabase;
+
+my $schema = DBICx::TestDatabase->connect('MySchema', undef, { 'quote-char' => '"' });
+ok($schema->storage->connect_info->[-1]{'quote-char'});


### PR DESCRIPTION
This could be used to pass the "quote-char" option.
So table/column identifiers with special chars are supported by the test database.
